### PR TITLE
Add fetching stream info

### DIFF
--- a/StreamStatus.go
+++ b/StreamStatus.go
@@ -316,7 +316,6 @@ func (s *StreamersRepo) eventsubStatus(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(200)
 		w.Write([]byte("ok"))
 
-
 		s.streamer = offlineEvent.BroadcasterUserName
 		s.online = false
     s.language = ""

--- a/StreamStatus.go
+++ b/StreamStatus.go
@@ -358,9 +358,9 @@ func (s *StreamersRepo) eventsubStatus(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func (s *StreamersRepo) fetchStreamInfo(user_login string) (*helix.Stream, error) {
+func (s *StreamersRepo) fetchStreamInfo(user_id string) (*helix.Stream, error) {
   streams, err := s.client.GetStreams(&helix.StreamsParams{
-    UserLogins: []string{user_login},
+    UserIDs: []string{user_id},
   })
   if err != nil {
     return nil, err

--- a/StreamStatus.go
+++ b/StreamStatus.go
@@ -433,10 +433,6 @@ func main() {
 		url:           repoUrl,
     client:         client,
 	}
-
-  // Test auth token works
-  // log.Print(repo.fetchStreamInfo("alh4zr3d"))
-
 	port := ":8080"
 	// Google Cloud Run defaults to 8080. Their platform
 	// sets the $PORT ENV var if you override it with, e.g.:


### PR DESCRIPTION
This commit adds the functionality to fetch additional info from the
twitch "streams" API. This is then used to display streamers streaming
non-infosec stuff (filtered by the game name) as offline and also
display the listed language.

The updateStreamStatus() function was also completley rewritten to make
the additional displayed info easier to implement.

I am adding this as a draft as:
- I have yet to test markdown generation as it's a bit of a pain to setup eventsub
- Table headers need to be changed
- Might also want to display language in a more pretty way (e.g. emoji)

Anyways let me know what you think :heart: 
btw this is aiming to fix https://github.com/infosecstreams/infosecstreams.github.io/issues/59