### PR TITLE
Fixed header type to match the retry event.

### DIFF
--- a/StreamStatus.go
+++ b/StreamStatus.go
@@ -280,8 +280,8 @@ type eventSubNotification struct {
 
 // eventsubStatus takes and http Request and ResponseWriter to handle the incoming webhook request.
 func (s *StreamersRepo) eventsubStatus(w http.ResponseWriter, r *http.Request) {
-	// Check the requests headers for Twitch-Eventsub-Message-Type and return 200, OK if it's != 0 and return.
-	if r.Header.Get("Twitch-Eventsub-Message-Type") != "0" {
+	// Check the requests headers for Twitch-Eventsub-Message-Retry and return 200, OK if it's != 0 and return.
+	if r.Header.Get("Twitch-Eventsub-Message-Retry") != "0" {
 		w.WriteHeader(http.StatusOK)
 		w.Write([]byte("OK"))
 		fmt.Println("Ignoring duplicate event from Twitch for Event")

--- a/StreamStatus.go
+++ b/StreamStatus.go
@@ -280,6 +280,14 @@ type eventSubNotification struct {
 
 // eventsubStatus takes and http Request and ResponseWriter to handle the incoming webhook request.
 func (s *StreamersRepo) eventsubStatus(w http.ResponseWriter, r *http.Request) {
+	// Check the requests headers for Twitch-Eventsub-Message-Type and return 200, OK if it's != 0 and return.
+	if r.Header.Get("Twitch-Eventsub-Message-Type") != "0" {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("OK"))
+		fmt.Println("Ignoring duplicate event from Twitch for Event")
+		return
+	}
+
 	// Read the request body.
 	body, err := ioutil.ReadAll(r.Body)
 	if err != nil {


### PR DESCRIPTION
Fixed the header call from `Twitch-Eventsub-Message-Type` which returns `[notification,webhook_callback_verification,revocation]` to `Twitch-Eventsub-Message-Retry` which returns an int.